### PR TITLE
Fix datetime serialization in list_local_models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,9 @@ addopts = [
     "--tb=short",
     "--strict-markers",
 ]
+asyncio_mode = "auto"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
+    "asyncio",
 ]

--- a/src/ollama_mcp/client.py
+++ b/src/ollama_mcp/client.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
+from datetime import datetime
 import ollama
 
 logger = logging.getLogger(__name__)
@@ -94,15 +95,20 @@ class OllamaClient:
             response = await self.client.list()
             raw_models = response.get('models', [])
             
-            models = [
-                ModelInfo(
+            models = []
+            for model in raw_models:
+                modified_at = model.get('modified_at')
+                if modified_at and hasattr(modified_at, 'isoformat'):
+                    modified_str = modified_at.isoformat()
+                else:
+                    modified_str = str(modified_at) if modified_at is not None else 'unknown'
+
+                models.append(ModelInfo(
                     name=model.get('name', 'unknown'),
                     size=model.get('size', 0),
-                    modified=model.get('modified_at', 'unknown')
-                )
-                for model in raw_models
-            ]
-            
+                    modified=modified_str
+                ))
+
             return {"success": True, "models": models, "count": len(models)}
             
         except asyncio.TimeoutError:


### PR DESCRIPTION
The `list_local_models` tool was failing with a `TypeError` because it was trying to JSON-serialize a `datetime` object.

This commit fixes the issue by converting the `datetime` object to an ISO 8601 formatted string in the `OllamaClient.list_models` method.

This commit also includes changes to the `pyproject.toml` file to correctly configure the test environment, which was necessary to verify the fix.