### PR TITLE
Update Python requirement to >=3.10 and add runtime check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,26 +11,25 @@ authors = [
 ]
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.22.0",
     "ollama>=0.3.0",
     "psutil>=5.9.0",
     "aiofiles>=23.0.0",
     "PyYAML>=6.0.0",
 ]
+
 
 [project.optional-dependencies]
 dev = [
@@ -56,7 +55,7 @@ where = ["src"]
 
 [tool.black]
 line-length = 88
-target-version = ['py38']
+target-version = ['py310']
 include = '\.pyi?$'
 
 [tool.isort]
@@ -65,7 +64,7 @@ multi_line_output = 3
 line_length = 88
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
### Summary

This PR updates the ollama-mcp-server project to require **Python 3.10 or higher**.  
It also adds a **runtime check** to provide a clear error message if someone tries to run the package on an older Python version.

---

### **Changes Made**

1. **pyproject.toml**
   - Updated `requires-python` to `>=3.10`.
   - Removed Python 3.8 and 3.9 classifiers; kept 3.10+ only.
   - Updated Black target version to `py310`.
   - Updated Mypy `python_version` to `3.10`.

2. **src/ollama_mcp/__init__.py**
   - Added runtime check:

```python
import sys

if sys.version_info < (3, 10):
    raise RuntimeError(
        "ollama-mcp-server requires Python 3.10 or higher. "
        f"You are using Python {sys.version_info.major}.{sys.version_info.minor}"
    )
